### PR TITLE
Fix some includes for build errors

### DIFF
--- a/include/accumulator.h
+++ b/include/accumulator.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <utility>
 #include <vector>
+#include <cassert>
 
 namespace utreexo {
 using Hash = std::array<uint8_t, 32>;

--- a/include/batchproof.h
+++ b/include/batchproof.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <stdint.h>
 #include <vector>
+#include <algorithm>
 
 namespace utreexo {
 

--- a/src/batchproof.cpp
+++ b/src/batchproof.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <cstring>
 #include <iostream>
+#include <tuple>
 
 namespace utreexo {
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <memory>
 #include <state.h>
+#include <cassert>
 
 namespace utreexo {
 


### PR DESCRIPTION
Running the following:

```console
$ ./autogen.sh
$ ./configure
$ make
```

I got a few build errors (which were easily fixed by just adding a few includes).