### PR TITLE
accumulator: Add include to fix build.

### DIFF
--- a/include/accumulator.h
+++ b/include/accumulator.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 #include <memory>
+#include <stdexcept>
 
 namespace utreexo {
 using Hash = std::array<uint8_t, 32>;


### PR DESCRIPTION
On Linux, the current master would throw a build error that stated that
std::runtime_error is not a part of std. Adding this fixes it.