### PR TITLE
test: additions to unit tests

### DIFF
--- a/src/test/state_tests.cpp
+++ b/src/test/state_tests.cpp
@@ -25,6 +25,18 @@ BOOST_AUTO_TEST_CASE(positions)
      * 00  01  02  03  04  05  06  07  08  09  10  11  12  13  14
     */
 
+    /*
+     *  11100
+     *  |-----------------------\
+     *  11000                   11001                   11010
+     *  |-----------\           |-----------\           |-----------\
+     *  10000       10001       10010       10011       10100       10101       10110
+     *  |-----\     |-----\     |-----\     |-----\     |-----\     |-----\     |-----\
+     *  00000 00001 00010 00011 00100 00101 00110 00111 01000 01001 01010 01011 01100 01101 01110
+    */
+   // the bits visualization helps to better understand the algorithms
+   // https://github.com/mit-dci/utreexo/blob/master/accumulator/printout.txt
+
     ForestState state(15);
 
     BOOST_CHECK(state.LeftChild(28) == 24);


### PR DESCRIPTION
The main change is the addition of the `ramforest_undo` test case, together with some minor changes that occurred as I was exploring the codebase :
- minor change in simple_blockchain test
   - We were not updating the roots [after the Undo](https://github.com/mit-dci/libutreexo/compare/master...kouloumos:tests-additions?expand=1#diff-693bb3acc313996333bda0496be29b5db165750930e40142648d59fc29e526aeR425), so as it is, it just checks that the <UndoBatch, pre-modification roots> pair is correctly inserted in the vector. My understanding is that the intention there is to check that the roots after the Undo are the same as  before the modification.  
- test for out of order targets in Modify()
   - [minor addition](https://github.com/mit-dci/libutreexo/compare/master...kouloumos:tests-additions?expand=1#diff-693bb3acc313996333bda0496be29b5db165750930e40142648d59fc29e526aeL318-R320) to cover an untested path that I found during test coverage
- more comments