### PR TITLE
state: simplify `numRows` helper by only counting bits

### DIFF
--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1,3 +1,5 @@
+#include "crypto/common.h"
+
 #include <algorithm>
 #include <bitset>
 #include <check.h>
@@ -308,35 +310,8 @@ uint8_t ForestState::RootIndex(uint64_t pos) const
 
 uint8_t _numRows(uint64_t num_leaves)
 {
-    // numRows works by:
-    // 1. Find the next power of 2 from the given n leaves.
-    // 2. Calculate the log2 of the result from step 1.
-    //
-    // For example, if the given number is 9, the next power of 2 is
-    // 16. This log2 of this number is how many rows there are in the
-    // given tree.
-    //
-    // This works because while Utreexo is a collection of perfect
-    // trees, the allocated number of leaves is always a power of 2.
-    // For Utreexo trees that don't have leaves that are power of 2,
-    // the extra space is just unallocated/filled with zeros.
-
-    // Find the next power of 2
-
-    uint64_t n = num_leaves;
-    --n;
-    n |= n >> 1;
-    n |= n >> 2;
-    n |= n >> 4;
-    n |= n >> 8;
-    n |= n >> 16;
-    n |= n >> 32;
-    ++n;
-
-    // log of 2 is the tree depth/height
-    // if n == 0, there will be 64 traling zeros but actually no tree rows.
-    // we clear the 6th bit to return 0 in that case.
-    return uint8_t(trailingZeros(n) & ~64ULL);
+    if (num_leaves == 0) return 0;
+    return CountBits(num_leaves - 1);
 }
 
 


### PR DESCRIPTION
This simplification was first proposed for pytreexo (see https://github.com/utreexo/pytreexo/pull/3: _"This helper basically calculates the number of trailing zeros of the next power of two of the input number, which can be simply achieved by counting the number of bits after the input number is reduced by 1 (to take perfect powers of two into account)."_)  and was then also adapted for the go and rust implementations, see https://github.com/utreexo/utreexo/pull/72 and https://github.com/mit-dci/rustreexo/pull/18.

Not sure if this repository is still maintained (apparently there hasn't been activity for almost 10 months?), but in case someone still has interest or forks off in the future, here's the same refactoring change for the C++ implementation.